### PR TITLE
Screen is cut off when the program exits

### DIFF
--- a/ssd1306.c
+++ b/ssd1306.c
@@ -1,4 +1,5 @@
 #include "ssd1306.h"
+#include "ssd1306_conf.h"
 #include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -116,6 +117,9 @@ void ssd1306_UpdateScreen(void) {
   }
 
   fflush(stdout);
+
+  // Move terminal cursor below the screen
+  printf("\033[%d;%dH", SSD1306_HEIGHT + 3, 1);
 }
 
 /*


### PR DESCRIPTION
Fixes #4.

The issue was the terminal cursor being left in place of the last rendered pixel, which on exit caused the terminal prompt to cut off part of the screen below it. Moving the cursor one line below the bottom screen frame after each redraw fixes the issue.