### PR TITLE
Experimental: Octant renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ A frame is added to show screen boundaries.
 It uses partial redraw (draws only changed pixels) to conserve resources and improve performance.
 
 > [!NOTE]
-> Rendering performance may vary between terminal emulators. While Linux terminals can comfortably draw at 2000+ FPS,
-on Windows it's common to have around 10 FPS due to Windows console being really slow and inefficient.
+> Rendering performance may vary between platforms and terminal emulators.
 
 In addition to functions available in the [original library](https://github.com/afiskon/stm32-ssd1306),
 it offers PC implementations of `HAL_GetTick` and `HAL_Delay` which might be useful for writing code
@@ -58,6 +57,7 @@ You should see the square appear in the terminal:
 | [`ssd1306_conf.h`](ssd1306_conf.h) | Screen configuration and enabled fonts |
 | [`ssd1306_fonts.h`](ssd1306_fonts.h) | Fonts for writing text to the screen |
 | [`ssd1306_tests.h`](ssd1306_tests.h) | Various tests for exploring functionality and learning |
+| [`experimental.h`](experimental.h) | Experimental features that must be enabled and are not guaranteed to work |
 
 ## Supported platforms
 
@@ -148,8 +148,8 @@ screen resolution:
 ```
 
 > [!WARNING]
-> Height must be an even number or else the last row won't be rendered. This limitation stems from
-added optimizations.
+> Height must be an even number or else the last row won't be rendered.
+This limitation stems from use of half blocks for rendering.
 
 ### Fonts
 There are a number of fonts included with the library. Their use can be toggled with `#define`:
@@ -166,6 +166,22 @@ There are a number of fonts included with the library. Their use can be toggled 
 ```
 
 If you wish to use custom fonts, see [this example](https://github.com/afiskon/stm32-ssd1306/tree/master/examples/custom-fonts) in the original library repo.
+
+### Experimental features
+Experimental features are not guaranteed to work and can be enabled using flags.
+You need to include [`experimental.h`](experimental.h) to use them.
+
+#### Octant renderer
+Uses [octants](https://wiki.ourworldoftext.com/wiki/Octant) for rendering instead of half blocks.
+This greatly improves performance at the cost of compatibility, as not every terminal font supports them.
+Octant renderer requires height to be divisible by 4 and width must be an even number.
+This is a technical limitation as one octant represents 2x4 area of pixels.
+
+Octant renderer can be enabled by adding:
+```c
+#define EXP_OCTANT_RENDERER
+```
+to [`ssd1306_conf.h`](ssd1306_conf.h).
 
 ## Credits
 

--- a/experimental.c
+++ b/experimental.c
@@ -1,0 +1,181 @@
+#include "experimental.h"
+#include "ssd1306.h"
+#include "stdint.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+static const char* octant_table[256] = {
+    " ",    "𜺨", "𜺫", "🮂",    "𜴀", "▘",    "𜴁", "𜴂", "𜴃", "𜴄", "▝",    "𜴅",
+    "𜴆", "𜴇", "𜴈", "▀",    "𜴉", "𜴊", "𜴋", "𜴌", "🯦", "𜴍", "𜴎", "𜴏",
+    "𜴐", "𜴑", "𜴒", "𜴓", "𜴔", "𜴕", "𜴖", "𜴗", "𜴘", "𜴙", "𜴚", "𜴛",
+    "𜴜", "𜴝", "𜴞", "𜴟", "🯧", "𜴠", "𜴡", "𜴢", "𜴣", "𜴤", "𜴥", "𜴦",
+    "𜴧", "𜴨", "𜴩", "𜴪", "𜴫", "𜴬", "𜴭", "𜴮", "𜴯", "𜴰", "𜴱", "𜴲",
+    "𜴳", "𜴴", "𜴵", "🮅",    "𜺣", "𜴶", "𜴷", "𜴸", "𜴹", "𜴺", "𜴻", "𜴼",
+    "𜴽", "𜴾", "𜴿", "𜵀", "𜵁", "𜵂", "𜵃", "𜵄", "▖",    "𜵅", "𜵆", "𜵇",
+    "𜵈", "▌",    "𜵉", "𜵊", "𜵋", "𜵌", "▞",    "𜵍", "𜵎", "𜵏", "𜵐", "▛",
+    "𜵑", "𜵒", "𜵓", "𜵔", "𜵕", "𜵖", "𜵗", "𜵘", "𜵙", "𜵚", "𜵛", "𜵜",
+    "𜵝", "𜵞", "𜵟", "𜵠", "𜵡", "𜵢", "𜵣", "𜵤", "𜵥", "𜵦", "𜵧", "𜵨",
+    "𜵩", "𜵪", "𜵫", "𜵬", "𜵭", "𜵮", "𜵯", "𜵰", "𜺠", "𜵱", "𜵲", "𜵳",
+    "𜵴", "𜵵", "𜵶", "𜵷", "𜵸", "𜵹", "𜵺", "𜵻", "𜵼", "𜵽", "𜵾", "𜵿",
+    "𜶀", "𜶁", "𜶂", "𜶃", "𜶄", "𜶅", "𜶆", "𜶇", "𜶈", "𜶉", "𜶊", "𜶋",
+    "𜶌", "𜶍", "𜶎", "𜶏", "▗",    "𜶐", "𜶑", "𜶒", "𜶓", "▚",    "𜶔", "𜶕",
+    "𜶖", "𜶗", "▐",    "𜶘", "𜶙", "𜶚", "𜶛", "▜",    "𜶜", "𜶝", "𜶞", "𜶟",
+    "𜶠", "𜶡", "𜶢", "𜶣", "𜶤", "𜶥", "𜶦", "𜶧", "𜶨", "𜶩", "𜶪", "𜶫",
+    "▂",    "𜶬", "𜶭", "𜶮", "𜶯", "𜶰", "𜶱", "𜶲", "𜶳", "𜶴", "𜶵", "𜶶",
+    "𜶷", "𜶸", "𜶹", "𜶺", "𜶻", "𜶼", "𜶽", "𜶾", "𜶿", "𜷀", "𜷁", "𜷂",
+    "𜷃", "𜷄", "𜷅", "𜷆", "𜷇", "𜷈", "𜷉", "𜷊", "𜷋", "𜷌", "𜷍", "𜷎",
+    "𜷏", "𜷐", "𜷑", "𜷒", "𜷓", "𜷔", "𜷕", "𜷖", "𜷗", "𜷘", "𜷙", "𜷚",
+    "▄",    "𜷛", "𜷜", "𜷝", "𜷞", "▙",    "𜷟", "𜷠", "𜷡", "𜷢", "▟",    "𜷣",
+    "▆",    "𜷤", "𜷥", "█",
+};
+
+void octantrenderer_UpdateScreen(
+    uint8_t SSD1306_Buffer[SSD1306_BUFFER_SIZE], uint8_t SSD1306_TerminalBuffer[SSD1306_BUFFER_SIZE]
+) {
+  uint16_t x, y;
+
+  static bool draw_start = true;
+  if (draw_start) {
+    // Print top border only at the start
+    printf("╔");
+    for (x = 0; x < SSD1306_WIDTH / 2; x++)
+      printf("═");
+    printf("╗\n");
+  }
+
+  // Skip over to handle 2x4 batches of pixels at once
+  for (y = 0; y < SSD1306_HEIGHT - 3; y += 4) {
+    if (draw_start)
+      printf("║"); // Left border
+
+    bool move_cursor = draw_start ? false : true;
+
+    for (x = 0; x < SSD1306_WIDTH - 1; x += 2) {
+      // Get 2x4 area of pixels
+      size_t pixel_1_buffer_index = x + (y / 8) * SSD1306_WIDTH;
+      size_t pixel_2_buffer_index = (x + 1) + (y / 8) * SSD1306_WIDTH;
+      size_t pixel_3_buffer_index = x + ((y + 1) / 8) * SSD1306_WIDTH;
+      size_t pixel_4_buffer_index = (x + 1) + ((y + 1) / 8) * SSD1306_WIDTH;
+      size_t pixel_5_buffer_index = x + ((y + 2) / 8) * SSD1306_WIDTH;
+      size_t pixel_6_buffer_index = (x + 1) + ((y + 2) / 8) * SSD1306_WIDTH;
+      size_t pixel_7_buffer_index = x + ((y + 3) / 8) * SSD1306_WIDTH;
+      size_t pixel_8_buffer_index = (x + 1) + ((y + 3) / 8) * SSD1306_WIDTH;
+
+      uint8_t row_1_offset = 1 << (y % 8);
+      uint8_t row_2_offset = 1 << ((y + 1) % 8);
+      uint8_t row_3_offset = 1 << ((y + 2) % 8);
+      uint8_t row_4_offset = 1 << ((y + 3) % 8);
+
+      // If all pixels haven't changed, do not re-render them
+      if (!draw_start &&
+          !((SSD1306_Buffer[pixel_1_buffer_index] ^ SSD1306_TerminalBuffer[pixel_1_buffer_index]) &
+            row_1_offset) &&
+          !((SSD1306_Buffer[pixel_2_buffer_index] ^ SSD1306_TerminalBuffer[pixel_2_buffer_index]) &
+            row_1_offset) &&
+          !((SSD1306_Buffer[pixel_3_buffer_index] ^ SSD1306_TerminalBuffer[pixel_3_buffer_index]) &
+            row_2_offset) &&
+          !((SSD1306_Buffer[pixel_4_buffer_index] ^ SSD1306_TerminalBuffer[pixel_4_buffer_index]) &
+            row_2_offset) &&
+          !((SSD1306_Buffer[pixel_5_buffer_index] ^ SSD1306_TerminalBuffer[pixel_5_buffer_index]) &
+            row_3_offset) &&
+          !((SSD1306_Buffer[pixel_6_buffer_index] ^ SSD1306_TerminalBuffer[pixel_6_buffer_index]) &
+            row_3_offset) &&
+          !((SSD1306_Buffer[pixel_7_buffer_index] ^ SSD1306_TerminalBuffer[pixel_7_buffer_index]) &
+            row_4_offset) &&
+          !((SSD1306_Buffer[pixel_8_buffer_index] ^ SSD1306_TerminalBuffer[pixel_8_buffer_index]) &
+            row_4_offset)) {
+        move_cursor = true;
+        continue;
+      }
+
+      // Synchronize buffers
+      if (SSD1306_Buffer[pixel_1_buffer_index] & row_1_offset)
+        SSD1306_TerminalBuffer[pixel_1_buffer_index] |= row_1_offset;
+      else
+        SSD1306_TerminalBuffer[pixel_1_buffer_index] &= ~row_1_offset;
+
+      if (SSD1306_Buffer[pixel_2_buffer_index] & row_1_offset)
+        SSD1306_TerminalBuffer[pixel_2_buffer_index] |= row_1_offset;
+      else
+        SSD1306_TerminalBuffer[pixel_2_buffer_index] &= ~row_1_offset;
+
+      if (SSD1306_Buffer[pixel_3_buffer_index] & row_2_offset)
+        SSD1306_TerminalBuffer[pixel_3_buffer_index] |= row_2_offset;
+      else
+        SSD1306_TerminalBuffer[pixel_3_buffer_index] &= ~row_2_offset;
+
+      if (SSD1306_Buffer[pixel_4_buffer_index] & row_2_offset)
+        SSD1306_TerminalBuffer[pixel_4_buffer_index] |= row_2_offset;
+      else
+        SSD1306_TerminalBuffer[pixel_4_buffer_index] &= ~row_2_offset;
+
+      if (SSD1306_Buffer[pixel_5_buffer_index] & row_3_offset)
+        SSD1306_TerminalBuffer[pixel_5_buffer_index] |= row_3_offset;
+      else
+        SSD1306_TerminalBuffer[pixel_5_buffer_index] &= ~row_3_offset;
+
+      if (SSD1306_Buffer[pixel_6_buffer_index] & row_3_offset)
+        SSD1306_TerminalBuffer[pixel_6_buffer_index] |= row_3_offset;
+      else
+        SSD1306_TerminalBuffer[pixel_6_buffer_index] &= ~row_3_offset;
+
+      if (SSD1306_Buffer[pixel_7_buffer_index] & row_4_offset)
+        SSD1306_TerminalBuffer[pixel_7_buffer_index] |= row_4_offset;
+      else
+        SSD1306_TerminalBuffer[pixel_7_buffer_index] &= ~row_4_offset;
+
+      if (SSD1306_Buffer[pixel_8_buffer_index] & row_4_offset)
+        SSD1306_TerminalBuffer[pixel_8_buffer_index] |= row_4_offset;
+      else
+        SSD1306_TerminalBuffer[pixel_8_buffer_index] &= ~row_4_offset;
+
+      if (move_cursor) {
+        // Move terminal cursor to the position of the pixel batch using escape codes
+        printf("\033[%d;%dH", y / 4 + 2, x / 2 + 2);
+        move_cursor = false;
+      }
+
+      // Calculate octant
+      uint8_t octant_selector = 0x00;
+
+      if (SSD1306_Buffer[pixel_1_buffer_index] & row_1_offset)
+        octant_selector |= 1;
+      if (SSD1306_Buffer[pixel_2_buffer_index] & row_1_offset)
+        octant_selector |= 1 << 1;
+      if (SSD1306_Buffer[pixel_3_buffer_index] & row_2_offset)
+        octant_selector |= 1 << 2;
+      if (SSD1306_Buffer[pixel_4_buffer_index] & row_2_offset)
+        octant_selector |= 1 << 3;
+      if (SSD1306_Buffer[pixel_5_buffer_index] & row_3_offset)
+        octant_selector |= 1 << 4;
+      if (SSD1306_Buffer[pixel_6_buffer_index] & row_3_offset)
+        octant_selector |= 1 << 5;
+      if (SSD1306_Buffer[pixel_7_buffer_index] & row_4_offset)
+        octant_selector |= 1 << 6;
+      if (SSD1306_Buffer[pixel_8_buffer_index] & row_4_offset)
+        octant_selector |= 1 << 7;
+
+      printf("%s", octant_table[octant_selector]);
+    }
+
+    if (draw_start)
+      printf("║\n"); // Right border
+  }
+
+  if (draw_start) {
+    // Bottom border
+    printf("╚");
+    for (x = 0; x < SSD1306_WIDTH / 2; x++)
+      printf("═");
+    printf("╝\n");
+
+    // Initial drawing has ended. Now rely on line updates
+    draw_start = false;
+  }
+
+  fflush(stdout);
+
+  // Move terminal cursor below the screen
+  printf("\033[%d;%dH", SSD1306_HEIGHT / 4 + 3, 1);
+}

--- a/experimental.c
+++ b/experimental.c
@@ -1,10 +1,13 @@
 #include "experimental.h"
 #include "ssd1306.h"
+#include "ssd1306_conf.h"
 #include "stdint.h"
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 
+#ifdef EXP_OCTANT_RENDERER
 static const char* octant_table[256] = {
     " ",    "𜺨", "𜺫", "🮂",    "𜴀", "▘",    "𜴁", "𜴂", "𜴃", "𜴄", "▝",    "𜴅",
     "𜴆", "𜴇", "𜴈", "▀",    "𜴉", "𜴊", "𜴋", "𜴌", "🯦", "𜴍", "𜴎", "𜴏",
@@ -33,7 +36,7 @@ static const char* octant_table[256] = {
 void octantrenderer_UpdateScreen(
     uint8_t SSD1306_Buffer[SSD1306_BUFFER_SIZE], uint8_t SSD1306_TerminalBuffer[SSD1306_BUFFER_SIZE]
 ) {
-  uint16_t x, y;
+  uint16_t x, y, i, j;
 
   static bool draw_start = true;
   if (draw_start) {
@@ -53,82 +56,39 @@ void octantrenderer_UpdateScreen(
 
     for (x = 0; x < SSD1306_WIDTH - 1; x += 2) {
       // Get 2x4 area of pixels
-      size_t pixel_1_buffer_index = x + (y / 8) * SSD1306_WIDTH;
-      size_t pixel_2_buffer_index = (x + 1) + (y / 8) * SSD1306_WIDTH;
-      size_t pixel_3_buffer_index = x + ((y + 1) / 8) * SSD1306_WIDTH;
-      size_t pixel_4_buffer_index = (x + 1) + ((y + 1) / 8) * SSD1306_WIDTH;
-      size_t pixel_5_buffer_index = x + ((y + 2) / 8) * SSD1306_WIDTH;
-      size_t pixel_6_buffer_index = (x + 1) + ((y + 2) / 8) * SSD1306_WIDTH;
-      size_t pixel_7_buffer_index = x + ((y + 3) / 8) * SSD1306_WIDTH;
-      size_t pixel_8_buffer_index = (x + 1) + ((y + 3) / 8) * SSD1306_WIDTH;
+      size_t pixel_buffer_indices[4][2];
+      uint8_t pixel_offsets[4];
 
-      uint8_t row_1_offset = 1 << (y % 8);
-      uint8_t row_2_offset = 1 << ((y + 1) % 8);
-      uint8_t row_3_offset = 1 << ((y + 2) % 8);
-      uint8_t row_4_offset = 1 << ((y + 3) % 8);
+      for (i = 0; i < 4; i++) {
+        for (j = 0; j < 2; j++)
+          pixel_buffer_indices[i][j] = (x + j) + ((y + i) / 8) * SSD1306_WIDTH;
+        pixel_offsets[i] = 1 << ((y + i) % 8);
+      }
 
       // If all pixels haven't changed, do not re-render them
-      if (!draw_start &&
-          !((SSD1306_Buffer[pixel_1_buffer_index] ^ SSD1306_TerminalBuffer[pixel_1_buffer_index]) &
-            row_1_offset) &&
-          !((SSD1306_Buffer[pixel_2_buffer_index] ^ SSD1306_TerminalBuffer[pixel_2_buffer_index]) &
-            row_1_offset) &&
-          !((SSD1306_Buffer[pixel_3_buffer_index] ^ SSD1306_TerminalBuffer[pixel_3_buffer_index]) &
-            row_2_offset) &&
-          !((SSD1306_Buffer[pixel_4_buffer_index] ^ SSD1306_TerminalBuffer[pixel_4_buffer_index]) &
-            row_2_offset) &&
-          !((SSD1306_Buffer[pixel_5_buffer_index] ^ SSD1306_TerminalBuffer[pixel_5_buffer_index]) &
-            row_3_offset) &&
-          !((SSD1306_Buffer[pixel_6_buffer_index] ^ SSD1306_TerminalBuffer[pixel_6_buffer_index]) &
-            row_3_offset) &&
-          !((SSD1306_Buffer[pixel_7_buffer_index] ^ SSD1306_TerminalBuffer[pixel_7_buffer_index]) &
-            row_4_offset) &&
-          !((SSD1306_Buffer[pixel_8_buffer_index] ^ SSD1306_TerminalBuffer[pixel_8_buffer_index]) &
-            row_4_offset)) {
+      bool pixel_changed = false;
+
+      for (i = 0; !pixel_changed && i < 4; i++)
+        for (j = 0; !pixel_changed && j < 2; j++)
+          if ((SSD1306_Buffer[pixel_buffer_indices[i][j]] ^
+               SSD1306_TerminalBuffer[pixel_buffer_indices[i][j]]) &
+              pixel_offsets[i])
+            pixel_changed = true;
+
+      if (!draw_start && !pixel_changed) {
         move_cursor = true;
         continue;
       }
 
       // Synchronize buffers
-      if (SSD1306_Buffer[pixel_1_buffer_index] & row_1_offset)
-        SSD1306_TerminalBuffer[pixel_1_buffer_index] |= row_1_offset;
-      else
-        SSD1306_TerminalBuffer[pixel_1_buffer_index] &= ~row_1_offset;
-
-      if (SSD1306_Buffer[pixel_2_buffer_index] & row_1_offset)
-        SSD1306_TerminalBuffer[pixel_2_buffer_index] |= row_1_offset;
-      else
-        SSD1306_TerminalBuffer[pixel_2_buffer_index] &= ~row_1_offset;
-
-      if (SSD1306_Buffer[pixel_3_buffer_index] & row_2_offset)
-        SSD1306_TerminalBuffer[pixel_3_buffer_index] |= row_2_offset;
-      else
-        SSD1306_TerminalBuffer[pixel_3_buffer_index] &= ~row_2_offset;
-
-      if (SSD1306_Buffer[pixel_4_buffer_index] & row_2_offset)
-        SSD1306_TerminalBuffer[pixel_4_buffer_index] |= row_2_offset;
-      else
-        SSD1306_TerminalBuffer[pixel_4_buffer_index] &= ~row_2_offset;
-
-      if (SSD1306_Buffer[pixel_5_buffer_index] & row_3_offset)
-        SSD1306_TerminalBuffer[pixel_5_buffer_index] |= row_3_offset;
-      else
-        SSD1306_TerminalBuffer[pixel_5_buffer_index] &= ~row_3_offset;
-
-      if (SSD1306_Buffer[pixel_6_buffer_index] & row_3_offset)
-        SSD1306_TerminalBuffer[pixel_6_buffer_index] |= row_3_offset;
-      else
-        SSD1306_TerminalBuffer[pixel_6_buffer_index] &= ~row_3_offset;
-
-      if (SSD1306_Buffer[pixel_7_buffer_index] & row_4_offset)
-        SSD1306_TerminalBuffer[pixel_7_buffer_index] |= row_4_offset;
-      else
-        SSD1306_TerminalBuffer[pixel_7_buffer_index] &= ~row_4_offset;
-
-      if (SSD1306_Buffer[pixel_8_buffer_index] & row_4_offset)
-        SSD1306_TerminalBuffer[pixel_8_buffer_index] |= row_4_offset;
-      else
-        SSD1306_TerminalBuffer[pixel_8_buffer_index] &= ~row_4_offset;
+      for (i = 0; i < 4; i++) {
+        for (j = 0; j < 2; j++) {
+          if (SSD1306_Buffer[pixel_buffer_indices[i][j]] & pixel_offsets[i])
+            SSD1306_TerminalBuffer[pixel_buffer_indices[i][j]] |= pixel_offsets[i];
+          else
+            SSD1306_TerminalBuffer[pixel_buffer_indices[i][j]] &= ~pixel_offsets[i];
+        }
+      }
 
       if (move_cursor) {
         // Move terminal cursor to the position of the pixel batch using escape codes
@@ -139,22 +99,10 @@ void octantrenderer_UpdateScreen(
       // Calculate octant
       uint8_t octant_selector = 0x00;
 
-      if (SSD1306_Buffer[pixel_1_buffer_index] & row_1_offset)
-        octant_selector |= 1;
-      if (SSD1306_Buffer[pixel_2_buffer_index] & row_1_offset)
-        octant_selector |= 1 << 1;
-      if (SSD1306_Buffer[pixel_3_buffer_index] & row_2_offset)
-        octant_selector |= 1 << 2;
-      if (SSD1306_Buffer[pixel_4_buffer_index] & row_2_offset)
-        octant_selector |= 1 << 3;
-      if (SSD1306_Buffer[pixel_5_buffer_index] & row_3_offset)
-        octant_selector |= 1 << 4;
-      if (SSD1306_Buffer[pixel_6_buffer_index] & row_3_offset)
-        octant_selector |= 1 << 5;
-      if (SSD1306_Buffer[pixel_7_buffer_index] & row_4_offset)
-        octant_selector |= 1 << 6;
-      if (SSD1306_Buffer[pixel_8_buffer_index] & row_4_offset)
-        octant_selector |= 1 << 7;
+      for (i = 0; i < 4; i++)
+        for (j = 0; j < 2; j++)
+          if (SSD1306_Buffer[pixel_buffer_indices[i][j]] & pixel_offsets[i])
+            octant_selector |= 1 << (2 * i + j);
 
       printf("%s", octant_table[octant_selector]);
     }
@@ -179,3 +127,4 @@ void octantrenderer_UpdateScreen(
   // Move terminal cursor below the screen
   printf("\033[%d;%dH", SSD1306_HEIGHT / 4 + 3, 1);
 }
+#endif

--- a/experimental.c
+++ b/experimental.c
@@ -122,9 +122,9 @@ void octantrenderer_UpdateScreen(
     draw_start = false;
   }
 
-  fflush(stdout);
-
   // Move terminal cursor below the screen
   printf("\033[%d;%dH", SSD1306_HEIGHT / 4 + 3, 1);
+
+  fflush(stdout);
 }
 #endif

--- a/experimental.h
+++ b/experimental.h
@@ -1,0 +1,11 @@
+#ifndef __EXPERIMENTAL_H__
+#define __EXPERIMENTAL_H__
+
+#include "ssd1306.h"
+#include "stdint.h"
+
+void octantrenderer_UpdateScreen(
+    uint8_t SSD1306_Buffer[SSD1306_BUFFER_SIZE], uint8_t SSD1306_TerminalBuffer[SSD1306_BUFFER_SIZE]
+);
+
+#endif // __EXPERIMENTAL_H__

--- a/ssd1306.c
+++ b/ssd1306.c
@@ -9,6 +9,10 @@
 #include <string.h>
 #include <unistd.h>
 
+#ifdef EXP_OCTANT_RENDERER
+#include "experimental.h"
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #elif defined(__linux__) || defined(__APPLE__)
@@ -64,6 +68,9 @@ void ssd1306_Fill(SSD1306_COLOR color) {
  * Uses partial redraw for best performance
  */
 void ssd1306_UpdateScreen(void) {
+#ifdef EXP_OCTANT_RENDERER
+  octantrenderer_UpdateScreen(SSD1306_Buffer, SSD1306_TerminalBuffer);
+#else
   uint16_t x, y;
 
   static bool draw_start = true;
@@ -148,6 +155,7 @@ void ssd1306_UpdateScreen(void) {
 
   // Move terminal cursor below the screen
   printf("\033[%d;%dH", SSD1306_HEIGHT / 2 + 3, 1);
+#endif
 }
 
 // Position the cursor

--- a/ssd1306.c
+++ b/ssd1306.c
@@ -32,6 +32,15 @@ static SSD1306_t SSD1306;
 
 // Initialize the screen and terminal with defaults
 void ssd1306_Init(void) {
+  // Set larger stdout buffer to fit the whole scene
+#ifdef EXP_OCTANT_RENDERER
+  char buffer_setvbuf[2048];
+  setvbuf(stdout, buffer_setvbuf, _IOFBF, sizeof buffer_setvbuf);
+#else
+  char buffer_setvbuf[2048 * 2];
+  setvbuf(stdout, buffer_setvbuf, _IOFBF, sizeof buffer_setvbuf);
+#endif
+
   // Clear terminal screen
 #ifdef _WIN32
   // Set proper codepage on Windows
@@ -151,10 +160,10 @@ void ssd1306_UpdateScreen(void) {
     draw_start = false;
   }
 
-  fflush(stdout);
-
   // Move terminal cursor below the screen
   printf("\033[%d;%dH", SSD1306_HEIGHT / 2 + 3, 1);
+
+  fflush(stdout);
 #endif
 }
 

--- a/ssd1306.c
+++ b/ssd1306.c
@@ -34,10 +34,10 @@ static SSD1306_t SSD1306;
 void ssd1306_Init(void) {
   // Set larger stdout buffer to fit the whole scene
 #ifdef EXP_OCTANT_RENDERER
-  char buffer_setvbuf[2048];
+  static char buffer_setvbuf[2048];
   setvbuf(stdout, buffer_setvbuf, _IOFBF, sizeof buffer_setvbuf);
 #else
-  char buffer_setvbuf[2048 * 2];
+  static char buffer_setvbuf[2048 * 2];
   setvbuf(stdout, buffer_setvbuf, _IOFBF, sizeof buffer_setvbuf);
 #endif
 

--- a/ssd1306_conf.h
+++ b/ssd1306_conf.h
@@ -23,10 +23,12 @@
 #define SSD1306_HEIGHT 64
 
 // Flags for enabling experimental features.
-// Experimental features are not guaranteed to work and are here for testing purposes
+// Experimental features are not guaranteed to work
 
-// Uses octants for rendering instead of half blocks. Greatly improves performance
-// at a cost of compatibility, as not every terminal font supports octants
+// Uses octants for rendering instead of half blocks. This greatly improves performance
+// at the cost of compatibility, as not every terminal font supports them.
+// Octant renderer requires height to be divisible by 4 and width must be an even number.
+// This is a technical limitation as one octant represents 2x4 area of pixels
 #define EXP_OCTANT_RENDERER
 
 #endif /* __SSD1306_CONF_H__ */

--- a/ssd1306_conf.h
+++ b/ssd1306_conf.h
@@ -29,6 +29,6 @@
 // at the cost of compatibility, as not every terminal font supports them.
 // Octant renderer requires height to be divisible by 4 and width must be an even number.
 // This is a technical limitation as one octant represents 2x4 area of pixels
-#define EXP_OCTANT_RENDERER
+// #define EXP_OCTANT_RENDERER
 
 #endif /* __SSD1306_CONF_H__ */

--- a/ssd1306_conf.h
+++ b/ssd1306_conf.h
@@ -22,4 +22,11 @@
 // The default value is 64
 #define SSD1306_HEIGHT 64
 
+// Flags for enabling experimental features.
+// Experimental features are not guaranteed to work and are here for testing purposes
+
+// Uses octants for rendering instead of half blocks. Greatly improves performance
+// at a cost of compatibility, as not every terminal font supports octants
+#define EXP_OCTANT_RENDERER
+
 #endif /* __SSD1306_CONF_H__ */


### PR DESCRIPTION
This adds octant renderer as an experimental feature. Experimental features are hidden behind flags found in the configuration file.

Octant renderer uses octants for rendering instead of half blocks. This greatly improves performance at the cost of compatibility, as not every terminal font supports them. Octant renderer requires height to be divisible by 4 and width must be an even number. This is a technical limitation as one octant represents 2x4 area of pixels.

Octant renderer can be enabled using the `EXP_OCTANT_RENDERER` flag.

With those changes also comes a fix for the low framerate on Windows in the form of setting a larger `stdout` buffer.

All changes have been properly documented and added to the README.